### PR TITLE
Typings, underscore properties & security vulnerabilities

### DIFF
--- a/.eslitrc.json
+++ b/.eslitrc.json
@@ -1,0 +1,1 @@
+index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+export class EventBus {
+	constructor();
+	on(target: object | null, events: string | null, handler: () => void, namespace?: string): this;
+	off(target: object | null, events: string | null, handler?: () => void, namespace?: string): this;
+	emit(target: object | null, events: string | null, data: unknown, namespace?: string): this;
+}
+
+declare const eventBus: EventBus;
+export default eventBus;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.13.0",
     "jest": "^26.6.3",
-    "jsdoc-to-markdown": "^6.0.1",
+    "jsdoc-to-markdown": "^7.1.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.33.1",
     "rollup-plugin-terser": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "types": "index.d.ts",
   "files": [
     "dist",
     "lib",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist",
     "lib",
-    "es"
+    "es",
+    "index.d.ts"
   ],
   "scripts": {
     "clean": "rimraf lib dist es coverage docs && mkdir docs",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsdoc-to-markdown": "^6.0.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.33.1",
-    "rollup-plugin-terser": "^6.1.0"
+    "rollup-plugin-terser": "^6.1.0",
+    "typescript": "^4.7.4"
   }
 }

--- a/src/class/EventBus.js
+++ b/src/class/EventBus.js
@@ -30,8 +30,8 @@ class EventBus {
 	 * Creates an event bus.
 	 */
 	constructor() {
-		this._evs = {};
-		this._qh = null;
+		Object.defineProperty(this, "_evs", { value: {}, enumerable: false });
+		Object.defineProperty(this, "_qh", { value: null, enumerable: false, writable: true });
 	}
 
 	/**
@@ -43,7 +43,7 @@ class EventBus {
 	 * @returns {this}
 	 */
 	on(target, events, handler, namespace) {
-		var i, hs, name, h;
+		let i, hs, name, h;
 
 		// Detect optional parameters
 		if (typeof events == 'function') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "include": [
+        "index.d.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "**/*.test.js"
+    ]
+}


### PR DESCRIPTION
This:
* add typings
* adds underscore properties via `defineProperty`, to make the non-enumerable
* updates `jsdoc-to-markdown` from **6.0.1** to **7.1.1** (I saw no changes in the generated docs)